### PR TITLE
refresh code: fix threading, remove custom url option (and supporting…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 # Note that this dockerfile is only used for development. deploying to GCP uses another container (per app.yaml)
 
-FROM python:3.10-slim 
-ENV PYTHONUNBUFFERED 1 
-COPY requirements.txt / 
-RUN pip3 install --no-cache-dir -r /requirements.txt 
-# requirements.txt does not include gunicorn, per google app engine instructions. for debugging this image will need it
-RUN pip3 install --no-cache-dir gunicorn 
-COPY main.py /app/ 
-COPY rss_config.py /app/ 
-COPY templates /app/templates 
-COPY static /app/static 
-WORKDIR /app 
+FROM python:3.10-slim
+ENV PYTHONUNBUFFERED 1
+COPY requirements.txt /
+RUN pip3 install --no-cache-dir -r /requirements.txt
+COPY main.py /app/
+COPY rss_config.py /app/
+COPY templates /app/templates
+COPY static /app/static
+WORKDIR /app
 CMD ["gunicorn", "--threads", "8","-b", "0.0.0.0:8080", "main:app"]

--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,8 @@
 runtime: python310
 instance_class: F1
+# Threaded gunicorn: the workload is I/O-bound (waiting on upstream feeds) and
+# the frontend fires ~20 parallel fetches per page load. Requires gunicorn in
+# requirements.txt (GAE only supplies gunicorn for the default entrypoint).
+entrypoint: gunicorn -b :$PORT --workers 1 --threads 16 --timeout 60 main:app
 automatic_scaling:
   max_instances: 2

--- a/main.py
+++ b/main.py
@@ -1,8 +1,6 @@
 import re
 import os
 import html
-import socket
-import ipaddress
 from urllib.parse import urlparse, parse_qsl, urlencode, urlunparse
 from html.parser import HTMLParser
 
@@ -20,14 +18,15 @@ app.config.from_object('rss_config')
 rss_feed_urls = app.config['RSS_FEEDS']
 
 URL_REGEX = re.compile(r'^https?://[^\s/$.?#].[^\s]*$', re.IGNORECASE)
-METADATA_HOSTS = {"metadata.google.internal", "metadata", "169.254.169.254"}
 REQUEST_HEADERS = {
     'user-agent': 'Mozilla/5.0 (X11; Linux i686; rv:109.0) Gecko/20100101 Firefox/120.0',
     'accept': '*/*'
 }
 MAX_FEED_ITEMS = 5
 MAX_FEED_BYTES = 3 * 1024 * 1024  # 3MB response cap
-ALLOWED_FEED_PORTS = {80, 443}
+# connect within 5s; abort after 15s of read inactivity (slow-to-first-byte
+# feeds like the redrss cloud function need the generous read side)
+REQUEST_TIMEOUT = (5, 15)
 HTTP_SESSION = requests.Session()
 HTTP_SESSION.headers.update(REQUEST_HEADERS)
 TRACKING_PARAM_KEYS = {
@@ -117,18 +116,9 @@ def truncate_at_word_boundary(text: str, max_length: int) -> str:
         truncated = truncated[:-1]
     return truncated + "..."
 
-def is_blocked_ip(ip_str: str) -> bool:
-    ip = ipaddress.ip_address(ip_str)
-    return any([
-        ip.is_loopback,
-        ip.is_private,
-        ip.is_link_local,
-        ip.is_multicast,
-        ip.is_reserved,
-        ip.is_unspecified,
-    ])
-
-def validate_feed_url(rss_feed_url: str, strict_ssrf: bool = False):
+def validate_feed_url(rss_feed_url: str):
+    # Feed URLs come only from rss_config.py; this sanity check makes a
+    # config typo fail with a clear error rather than a confusing one.
     if not rss_feed_url or not URL_REGEX.match(rss_feed_url):
         return False, "Malformed URL"
 
@@ -136,27 +126,8 @@ def validate_feed_url(rss_feed_url: str, strict_ssrf: bool = False):
     if parsed.scheme not in ("http", "https"):
         return False, "Only http/https URLs are allowed"
 
-    hostname = (parsed.hostname or "").lower().strip()
-    if not hostname:
+    if not (parsed.hostname or "").strip():
         return False, "URL must include a hostname"
-
-    if parsed.port and parsed.port not in ALLOWED_FEED_PORTS:
-        return False, "Blocked port"
-
-    if hostname in METADATA_HOSTS:
-        return False, "Blocked host"
-
-    if hostname == "localhost" or hostname.endswith(".localhost"):
-        return False, "Blocked host"
-
-    if strict_ssrf:
-        try:
-            for info in socket.getaddrinfo(hostname, None):
-                ip_str = info[4][0]
-                if is_blocked_ip(ip_str):
-                    return False, "Blocked host"
-        except Exception:
-            return False, "Unable to resolve host"
 
     return True, None
 
@@ -185,7 +156,19 @@ def sanitize_outbound_link(link: str) -> str:
     )
     return urlunparse(cleaned)
 
-def read_limited_response_text(response, max_bytes: int):
+def extract_site_link(feed) -> str:
+    # The feed's own website URL (<link> at channel level); used by the
+    # frontend to look up the site's favicon by its real domain.
+    link = feed.get('link')
+    if not link:
+        return None
+    link = str(link).strip()
+    parsed = urlparse(link)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return None
+    return link
+
+def read_limited_response_bytes(response, max_bytes: int):
     chunks = []
     total = 0
     for chunk in response.iter_content(chunk_size=65536, decode_unicode=False):
@@ -196,16 +179,15 @@ def read_limited_response_text(response, max_bytes: int):
             return None
         chunks.append(chunk)
 
-    body = b"".join(chunks)
-    encoding = response.encoding or "utf-8"
-    return body.decode(encoding, errors="replace")
+    return b"".join(chunks)
 
-def parse_feed_items(xml_string: str):
-    if len(xml_string) < 100:
+def parse_feed_items(xml_bytes: bytes):
+    if len(xml_bytes) < 100:
         return {'success': False, 'error': 'Bad feed data (response too short)'}
 
     try:
-        feed_parsed = feedparser.parse(xml_string)
+        # feedparser does BOM/XML-declaration-aware encoding detection on bytes
+        feed_parsed = feedparser.parse(xml_bytes)
     except Exception:
         return {'success': False, 'error': 'unable to parse'}
 
@@ -221,58 +203,60 @@ def parse_feed_items(xml_string: str):
         feed_items.append({
             'title': html.unescape(title),
             'summary': summary,
-            'url': html.unescape(link),
+            'url': link,
         })
 
         if len(feed_items) == MAX_FEED_ITEMS:
             break
 
     feed_title = ""
+    site_link = None
     try:
         feed_title = html.unescape(feed_parsed['feed'].get('title', 'Untitled Feed'))
+        site_link = extract_site_link(feed_parsed['feed'])
     except Exception:
         feed_title = "Untitled Feed"
 
-    return {'success': True, 'title': feed_title, 'feed_items': feed_items}
+    return {'success': True, 'title': feed_title, 'siteLink': site_link, 'feed_items': feed_items}
 
-def fetch_feed_payload(rss_feed_url: str, strict_ssrf: bool = False):
-    valid, error = validate_feed_url(rss_feed_url, strict_ssrf=strict_ssrf)
+def fetch_feed_payload(rss_feed_url: str):
+    valid, error = validate_feed_url(rss_feed_url)
     if not valid:
         return {'success': False, 'error': error, 'errorType': 'validation'}
 
     headers = {}
 
-    # If the URL contains cloudfunctions.net then get an auth token.
-    if 'cloudfunctions.net' in rss_feed_url:
-        auth_req = google.auth.transport.requests.Request()
-        id_token = google.oauth2.id_token.fetch_id_token(auth_req, rss_feed_url)
-        headers["Authorization"] = f"Bearer {id_token}"
+    # Cloud-function feeds need a service-to-service identity token.
+    hostname = (urlparse(rss_feed_url).hostname or "").lower()
+    if hostname.endswith(".cloudfunctions.net"):
+        try:
+            auth_req = google.auth.transport.requests.Request()
+            id_token = google.oauth2.id_token.fetch_id_token(auth_req, rss_feed_url)
+            headers["Authorization"] = f"Bearer {id_token}"
+        except Exception:
+            # no credentials available (local dev, Docker) or metadata server failure
+            return {'success': False, 'error': 'Unable to authenticate to feed backend', 'errorType': 'upstream'}
 
     try:
         response = HTTP_SESSION.get(
             rss_feed_url,
             headers=headers,
-            timeout=20,
-            allow_redirects=not strict_ssrf,
+            timeout=REQUEST_TIMEOUT,
             stream=True,
         )
     except Exception:
         return {'success': False, 'error': 'Unable to fetch feed URL', 'errorType': 'upstream'}
 
-    if strict_ssrf and response.is_redirect:
-        response.close()
-        return {'success': False, 'error': 'Redirects are not allowed', 'errorType': 'validation'}
-
     if not response.ok:
         response.close()
         return {'success': False, 'error': f'Server returned: {response.status_code}', 'errorType': 'upstream'}
 
-    xml_text = read_limited_response_text(response, MAX_FEED_BYTES)
+    xml_bytes = read_limited_response_bytes(response, MAX_FEED_BYTES)
     response.close()
-    if xml_text is None:
+    if xml_bytes is None:
         return {'success': False, 'error': 'Feed response too large', 'errorType': 'validation'}
 
-    return parse_feed_items(xml_text)
+    return parse_feed_items(xml_bytes)
 
 # Route to render the main page
 @app.route('/')
@@ -302,40 +286,17 @@ def api_default_feeds():
 def api_fetch_feed():
     payload = request.get_json(silent=True) or {}
     feed_ref = payload.get('feedRef') or {}
-    ref_type = feed_ref.get('type')
 
-    if ref_type == 'default':
-        index = feed_ref.get('index')
-        if not isinstance(index, int) or index < 1 or index > len(rss_feed_urls):
-            return jsonify({'success': False, 'error': 'feed index out of range'}), 400
-        result = fetch_feed_payload(rss_feed_urls[index - 1], strict_ssrf=False)
-        status_code = 200 if result.get('success') else 502
-        return jsonify(result), status_code
+    if feed_ref.get('type') != 'default':
+        return jsonify({'success': False, 'error': 'Unsupported feedRef.type'}), 400
 
-    if ref_type == 'url':
-        rss_feed_url = feed_ref.get('url')
-        result = fetch_feed_payload(rss_feed_url, strict_ssrf=True)
-        if result.get('success'):
-            status_code = 200
-        elif result.get('errorType') == 'validation':
-            status_code = 400
-        else:
-            status_code = 502
-        return jsonify(result), status_code
+    index = feed_ref.get('index')
+    if not isinstance(index, int) or isinstance(index, bool) or index < 1 or index > len(rss_feed_urls):
+        return jsonify({'success': False, 'error': 'feed index out of range'}), 400
 
-    return jsonify({'success': False, 'error': 'Unsupported feedRef.type'}), 400
-
-# Route to fetch and return the RSS feed as JSON
-@app.route('/fetch_feed/<int:feed_number>')
-def fetch_feed(feed_number):
-    if feed_number < 1 or feed_number > len(rss_feed_urls):
-        return jsonify({'success': False, 'error': f'feed index out of range: {feed_number}'})
-    return jsonify(fetch_feed_payload(rss_feed_urls[feed_number - 1], strict_ssrf=False))
-
-@app.route('/static/<path:filename>')
-def serve_static(filename):
-    root_dir = os.path.dirname(os.getcwd())
-    return send_from_directory(os.path.join(root_dir, 'static'), filename)
+    result = fetch_feed_payload(rss_feed_urls[index - 1])
+    status_code = 200 if result.get('success') else 502
+    return jsonify(result), status_code
 
 @app.route('/favicon.ico')
 def serve_favicon():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
-Flask
-feedparser
-requests
-google-auth
-blingfire
-numpy
+Flask==3.1.1
+feedparser==6.0.11
+requests==2.32.3
+google-auth==2.40.1
+blingfire==0.1.8
+# blingfire imports numpy at module level but does not declare it as a dependency
+numpy==2.2.6
+# required because app.yaml specifies a custom gunicorn entrypoint
+gunicorn==26.0.0

--- a/static/style.css
+++ b/static/style.css
@@ -178,11 +178,6 @@ tv-market-summary {
   background: var(--danger);
 }
 
-.btn-small {
-  padding: 0.3rem 0.55rem;
-  font-size: 0.8rem;
-}
-
 .customize-panel {
   border: 1px solid var(--line);
   background: rgba(248, 251, 255, 0.95);
@@ -197,60 +192,29 @@ tv-market-summary {
   display: none;
 }
 
-.customize-panel h2,
-.customize-panel h3 {
+.customize-panel h2 {
   font-family: "DM Serif Display", serif;
   margin: 0 0 0.65rem;
-}
-
-.add-feed-form {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 0.45rem;
-}
-
-.add-feed-form input {
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 0.5rem 0.65rem;
-  font-family: inherit;
-}
-
-.form-error {
-  margin: 0;
-  color: var(--danger);
-  font-weight: 700;
-}
-
-.customize-groups {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 0.8rem;
-  margin-top: 1rem;
 }
 
 .feed-toggle-list {
   list-style: none;
   padding: 0;
   margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 0 1.2rem;
 }
 
 .feed-toggle-list li {
   border-top: 1px solid var(--line);
-  padding: 0.55rem 0;
+  padding: 0.45rem 0;
 }
 
 .feed-toggle-list label {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 0.55rem;
-}
-
-.custom-feed-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.7rem;
 }
 
 .muted {
@@ -289,7 +253,7 @@ tv-market-summary {
   top: 0;
   height: 4px;
   border-radius: var(--radius) var(--radius) 0 0;
-  background: linear-gradient(90deg, var(--card-accent), var(--card-accent-2), var(--accent-2), var(--accent-4));
+  background: linear-gradient(90deg, var(--card-accent), var(--card-accent-2));
 }
 
 .feed-card:hover {
@@ -364,6 +328,13 @@ tv-market-summary {
 .favicon-wrap img {
   width: 17px;
   height: 17px;
+}
+
+.favicon-letter {
+  font-size: 0.82rem;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--card-accent);
 }
 
 .card-actions {

--- a/templates/home.html
+++ b/templates/home.html
@@ -31,7 +31,7 @@
         <div class="tv-widget-wrap">
           <script type="module" src="https://widgets.tradingview-widget.com/w/en/tv-market-summary.js"></script>
           <tv-market-summary
-            symbol-sectors='[{"sectionName":"Markets","symbols":["AMEX:SPY","FRED:VIXCLS","AMEX:GLD","COINBASE:BTCUSD"]}]'
+            symbol-sectors='[{"sectionName":"Markets","symbols":["COINBASE:BTCUSD","FRED:VIXCLS","AMEX:SPY","AMEX:GLD"]}]'
             item-size="compact"
             mode="custom">
           </tv-market-summary>
@@ -43,25 +43,7 @@
 
       <section id="customize-panel" class="customize-panel hidden" aria-label="Customize feed dashboard">
         <h2>Customize Dashboard</h2>
-        <form id="add-feed-form" class="add-feed-form">
-          <label for="feed-url-input">Add custom RSS feed URL</label>
-          <input id="feed-url-input" type="url" placeholder="https://example.com/rss.xml" required>
-          <label for="feed-label-input">Optional label</label>
-          <input id="feed-label-input" type="text" maxlength="80" placeholder="My feed">
-          <button class="btn btn-primary" type="submit">Add Feed</button>
-          <p id="add-feed-error" class="form-error hidden"></p>
-        </form>
-
-        <div class="customize-groups">
-          <div class="customize-group">
-            <h3>Default feeds</h3>
-            <ul id="default-feed-list" class="feed-toggle-list"></ul>
-          </div>
-          <div class="customize-group">
-            <h3>Custom feeds</h3>
-            <ul id="custom-feed-list" class="feed-toggle-list"></ul>
-          </div>
-        </div>
+        <ul id="default-feed-list" class="feed-toggle-list"></ul>
       </section>
 
       <section id="feed-grid" class="feed-grid" aria-live="polite"></section>
@@ -73,14 +55,18 @@
 
 <script>
 (() => {
-  const STORAGE_KEY = "rssboxes.dashboard.v2";
+  const STORAGE_KEY = "rssboxes.dashboard.v3";
+  const LEGACY_STORAGE_KEY = "rssboxes.dashboard.v2";
   const FEED_CACHE_KEY = "rssboxes.feedcache.v1";
   const FEED_CACHE_TTL_MS = 10 * 60 * 1000;
-  const EMPTY_PREFS = { order: [], hiddenDefaultIds: [], customFeeds: [], updatedAt: new Date().toISOString() };
+
+  function emptyPrefs() {
+    return { order: [], hiddenDefaultIds: [], updatedAt: new Date().toISOString() };
+  }
 
   const state = {
     defaults: [],
-    prefs: { ...EMPTY_PREFS },
+    prefs: emptyPrefs(),
     cards: new Map(),
     feedTitles: {},
     refreshRun: 0,
@@ -95,33 +81,33 @@
     lastUpdated: document.getElementById("last-updated"),
     customizePanel: document.getElementById("customize-panel"),
     defaultFeedList: document.getElementById("default-feed-list"),
-    customFeedList: document.getElementById("custom-feed-list"),
-    addFeedForm: document.getElementById("add-feed-form"),
-    addFeedError: document.getElementById("add-feed-error"),
-    feedUrlInput: document.getElementById("feed-url-input"),
-    feedLabelInput: document.getElementById("feed-label-input"),
     stonksFallback: document.getElementById("stonks-fallback"),
   };
 
   function loadPrefs() {
     try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (!raw) return { ...EMPTY_PREFS };
+      // Fall back to the v2 key once so existing visitors keep their
+      // order/hidden prefs; v2 customFeeds are dropped by normalizeOrder.
+      const raw = localStorage.getItem(STORAGE_KEY) || localStorage.getItem(LEGACY_STORAGE_KEY);
+      if (!raw) return emptyPrefs();
       const parsed = JSON.parse(raw);
       return {
         order: Array.isArray(parsed.order) ? parsed.order : [],
         hiddenDefaultIds: Array.isArray(parsed.hiddenDefaultIds) ? parsed.hiddenDefaultIds : [],
-        customFeeds: Array.isArray(parsed.customFeeds) ? parsed.customFeeds : [],
         updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : new Date().toISOString(),
       };
     } catch (_) {
-      return { ...EMPTY_PREFS };
+      return emptyPrefs();
     }
   }
 
   function savePrefs() {
     state.prefs.updatedAt = new Date().toISOString();
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state.prefs));
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state.prefs));
+    } catch (_) {
+      // storage unavailable (private browsing, quota) — run without persistence
+    }
   }
 
   function loadFeedCache() {
@@ -136,12 +122,15 @@
   }
 
   function saveFeedCache() {
-    localStorage.setItem(FEED_CACHE_KEY, JSON.stringify(state.feedCache));
+    try {
+      localStorage.setItem(FEED_CACHE_KEY, JSON.stringify(state.feedCache));
+    } catch (_) {
+      // storage unavailable — feeds simply refetch next load
+    }
   }
 
   function feedCacheKey(feed) {
-    if (feed.type === "default") return "default:" + feed.index;
-    return "custom:" + (feed.id || feed.sourceUrl);
+    return feed.id;
   }
 
   function getCachedPayload(feed) {
@@ -161,11 +150,6 @@
     saveFeedCache();
   }
 
-  function clearCachedPayload(feed) {
-    delete state.feedCache[feedCacheKey(feed)];
-    saveFeedCache();
-  }
-
   function pruneFeedCache() {
     const valid = new Set(getAllFeeds().map((feed) => feedCacheKey(feed)));
     for (const key of Object.keys(state.feedCache)) {
@@ -179,13 +163,11 @@
   }
 
   function sourceLabel(feed) {
-    if (feed.type === "custom" && feed.label) return feed.label;
     const host = parseHost(feed.sourceUrl);
     return host || feed.sourceUrl;
   }
 
   function listLabel(feed) {
-    if (feed.type === "custom" && feed.label) return feed.label;
     if (feed.displayName) return feed.displayName;
     if (state.feedTitles[feed.id]) return state.feedTitles[feed.id];
     return feed.sourceUrl;
@@ -203,8 +185,7 @@
     }
   }
 
-  function faviconUrl(url) {
-    const host = parseHost(url);
+  function faviconSrcForHost(host) {
     return host ? ("https://www.google.com/s2/favicons?sz=64&domain=" + encodeURIComponent(host)) : "";
   }
 
@@ -227,13 +208,11 @@
   }
 
   function getAllFeeds() {
-    const defaults = state.defaults.map((feed) => ({ ...feed, type: "default" }));
-    const customs = state.prefs.customFeeds.map((feed) => ({ ...feed, type: "custom" }));
-    return [...defaults, ...customs];
+    return state.defaults.map((feed) => ({ ...feed, type: "default" }));
   }
 
   function isHidden(feed) {
-    return feed.type === "default" && state.prefs.hiddenDefaultIds.includes(feed.id);
+    return state.prefs.hiddenDefaultIds.includes(feed.id);
   }
 
   function visibleFeedsInOrder() {
@@ -280,13 +259,23 @@
     sourceChip.className = "source-chip";
     const faviconWrap = document.createElement("span");
     faviconWrap.className = "favicon-wrap";
+    const monogram = document.createElement("span");
+    monogram.className = "favicon-letter";
+    monogram.textContent = (sourceLabel(feed).trim().charAt(0) || "?").toUpperCase();
     const favicon = document.createElement("img");
-    favicon.src = faviconUrl(feed.sourceUrl);
     favicon.alt = "";
     favicon.loading = "lazy";
+    favicon.style.display = "none";
+    favicon.addEventListener("load", () => {
+      favicon.style.display = "";
+      monogram.style.display = "none";
+    });
     favicon.addEventListener("error", () => {
       favicon.style.display = "none";
+      monogram.style.display = "";
     });
+    favicon.src = faviconSrcForHost(parseHost(feed.sourceUrl));
+    faviconWrap.appendChild(monogram);
     faviconWrap.appendChild(favicon);
     const title = document.createElement("h3");
     title.className = "feed-title";
@@ -325,6 +314,22 @@
     return card;
   }
 
+  function updateCardIcon(card, payload, feed) {
+    const monogram = card.querySelector(".favicon-letter");
+    if (monogram && payload.title) {
+      monogram.textContent = (payload.title.trim().charAt(0) || monogram.textContent).toUpperCase();
+    }
+    // The feed host (feeds.bbci.co.uk, ...) often has no favicon; the feed's
+    // declared website domain (bbc.co.uk, ...) almost always does.
+    if (!payload.siteLink) return;
+    const siteHost = parseHost(payload.siteLink);
+    if (!siteHost || siteHost === parseHost(feed.sourceUrl)) return;
+    const img = card.querySelector(".favicon-wrap img");
+    if (!img) return;
+    const next = faviconSrcForHost(siteHost);
+    if (img.src !== next) img.src = next;
+  }
+
   function renderCardContent(card, payload, feed) {
     if (!payload.success) {
       card.classList.remove("loading");
@@ -350,6 +355,7 @@
         renderFeedLists();
       }
     }
+    updateCardIcon(card, payload, feed);
     listEl.classList.remove("skeleton-list");
     listEl.innerHTML = "";
 
@@ -382,11 +388,9 @@
       }
     }
 
-    const feedRef = feed.type === "default"
-      ? { type: "default", index: feed.index }
-      : { type: "url", url: feed.sourceUrl };
-
-    const response = await apiPost("/api/v1/feeds/fetch", { feedRef });
+    const response = await apiPost("/api/v1/feeds/fetch", {
+      feedRef: { type: "default", index: feed.index },
+    });
     const payload = response.data || { success: false, error: "No response" };
     renderCardContent(card, payload, feed);
     if (payload.success) {
@@ -440,16 +444,30 @@
 
   function moveFeed(feedId, delta) {
     normalizeOrder();
-    const idx = state.prefs.order.indexOf(feedId);
-    if (idx === -1) return;
-    const target = idx + delta;
-    if (target < 0 || target >= state.prefs.order.length) return;
-    const clone = state.prefs.order.slice();
-    const [item] = clone.splice(idx, 1);
-    clone.splice(target, 0, item);
-    state.prefs.order = clone;
+    // Move relative to the visible neighbor so a hidden feed between two
+    // visible ones can't swallow the click.
+    const visible = visibleFeedsInOrder().map((feed) => feed.id);
+    const vIdx = visible.indexOf(feedId);
+    const tIdx = vIdx + delta;
+    if (vIdx === -1 || tIdx < 0 || tIdx >= visible.length) return;
+    const neighborId = visible[tIdx];
+
+    const order = state.prefs.order.filter((id) => id !== feedId);
+    const nPos = order.indexOf(neighborId);
+    if (nPos === -1) return;
+    order.splice(delta > 0 ? nPos + 1 : nPos, 0, feedId);
+    state.prefs.order = order;
     savePrefs();
-    renderGridAndFetch({ forceRefresh: false });
+
+    // Swap the DOM nodes in place — no grid rebuild, no refetch.
+    const moving = state.cards.get(feedId);
+    const neighbor = state.cards.get(neighborId);
+    if (!moving || !neighbor) return;
+    if (delta > 0) {
+      el.grid.insertBefore(neighbor.card, moving.card);
+    } else {
+      el.grid.insertBefore(moving.card, neighbor.card);
+    }
   }
 
   function toggleDefaultHidden(feedId, hidden) {
@@ -463,42 +481,8 @@
     renderGridAndFetch({ forceRefresh: false });
   }
 
-  function removeCustomFeed(feedId) {
-    state.prefs.customFeeds = state.prefs.customFeeds.filter((f) => f.id !== feedId);
-    state.prefs.order = state.prefs.order.filter((id) => id !== feedId);
-    savePrefs();
-    clearCachedPayload({ type: "custom", id: feedId });
-    pruneFeedCache();
-    normalizeOrder();
-    renderFeedLists();
-    renderGridAndFetch({ forceRefresh: false });
-  }
-
-  async function addCustomFeed(url, label) {
-    const trimmed = url.trim();
-    const test = await apiPost("/api/v1/feeds/fetch", { feedRef: { type: "url", url: trimmed } });
-    if (!test.data || !test.data.success) {
-      throw new Error(test.data?.error || "Could not validate feed");
-    }
-
-    const feedId = "custom:" + crypto.randomUUID();
-    state.prefs.customFeeds.push({
-      id: feedId,
-      url: trimmed,
-      sourceUrl: trimmed,
-      label: label.trim() || null,
-    });
-    state.prefs.order.push(feedId);
-    savePrefs();
-    pruneFeedCache();
-    normalizeOrder();
-    renderFeedLists();
-    renderGridAndFetch({ forceRefresh: false });
-  }
-
   function renderFeedLists() {
     el.defaultFeedList.innerHTML = "";
-    el.customFeedList.innerHTML = "";
 
     state.defaults.forEach((feed) => {
       const li = document.createElement("li");
@@ -516,35 +500,10 @@
       checkbox.addEventListener("change", () => toggleDefaultHidden(feed.id, !checkbox.checked));
       el.defaultFeedList.appendChild(li);
     });
-
-    if (!state.prefs.customFeeds.length) {
-      const empty = document.createElement("li");
-      empty.className = "muted";
-      empty.textContent = "No custom feeds yet.";
-      el.customFeedList.appendChild(empty);
-      return;
-    }
-
-    state.prefs.customFeeds.forEach((feed) => {
-      const li = document.createElement("li");
-      const row = document.createElement("div");
-      row.className = "custom-feed-row";
-      const text = document.createElement("span");
-      text.textContent = listLabel({ ...feed, type: "custom", sourceUrl: feed.sourceUrl || feed.url });
-      const removeBtn = document.createElement("button");
-      removeBtn.className = "btn btn-small btn-danger";
-      removeBtn.type = "button";
-      removeBtn.textContent = "Remove";
-      removeBtn.addEventListener("click", () => removeCustomFeed(feed.id));
-      row.appendChild(text);
-      row.appendChild(removeBtn);
-      li.appendChild(row);
-      el.customFeedList.appendChild(li);
-    });
   }
 
   function restoreDefaults() {
-    state.prefs = { ...EMPTY_PREFS };
+    state.prefs = emptyPrefs();
     savePrefs();
     state.feedCache = {};
     saveFeedCache();
@@ -567,19 +526,6 @@
     });
 
     el.restoreDefaults.addEventListener("click", restoreDefaults);
-
-    el.addFeedForm.addEventListener("submit", async (event) => {
-      event.preventDefault();
-      el.addFeedError.textContent = "";
-      el.addFeedError.classList.add("hidden");
-      try {
-        await addCustomFeed(el.feedUrlInput.value, el.feedLabelInput.value);
-        el.addFeedForm.reset();
-      } catch (error) {
-        el.addFeedError.textContent = error.message || "Could not add feed";
-        el.addFeedError.classList.remove("hidden");
-      }
-    });
 
     el.grid.addEventListener("click", (event) => {
       const button = event.target.closest("button[data-action]");


### PR DESCRIPTION
### Removed
- Custom feed URLs (UI + API); feeds are config-only via `rss_config.py`
- SSRF validation machinery (moot without user-supplied URLs)
- Legacy `GET /fetch_feed/<n>` route
- Broken custom `/static/` route (Flask built-in serves it)

### Fixed
- ID-token fetch: gated on `.cloudfunctions.net` hostname, no longer 500s without credentials
- Feed bytes passed to feedparser (encoding detection; no more mojibake)
- Double `html.unescape` corrupting item URLs (`&copy=` → `©`)
- `localStorage` writes guarded (private browsing no longer breaks UI)

### Changed
- `app.yaml`: explicit threaded gunicorn entrypoint (`--threads 16`) — feeds fetch in parallel instead of serializing
- `requirements.txt`: all versions pinned; gunicorn added (required by custom entrypoint); numpy kept (undeclared blingfire dep)
- Fetch timeout `20` → `(5, 15)` connect/read
- Card reorder swaps DOM nodes (no grid rebuild/flash)
- Prefs storage key v2 → v3 (order + hidden only; v2 read once as fallback)

### Added
- `siteLink` in fetch payload; favicon chip uses the feed's real site domain (fixes ~half the icons)
- Monogram fallback when favicon fails to load
- Per-card two-color accent stripe